### PR TITLE
[REFACTOR] KisTokenService 블로킹 통신 일관성 확보

### DIFF
--- a/backend/stock/src/main/java/com/sog/stock/application/service/StockServiceImpl.java
+++ b/backend/stock/src/main/java/com/sog/stock/application/service/StockServiceImpl.java
@@ -323,7 +323,7 @@ public class StockServiceImpl implements StockService {
     @Override
     public StockPresentPriceResponseDTO searchStockPresentPrice(String stockCode) {
         // kisToken redis에서
-        String token = kisTokenService.getAccessToken().block(); // 동기처리
+        String token = kisTokenService.getAccessToken();
         if (token == null) {
             throw new RuntimeException("kis 토큰 접근 실패");
         }
@@ -345,7 +345,7 @@ public class StockServiceImpl implements StockService {
     @Override
     public MinuteStockPriceListDTO getMinuteStockPriceList(String stockCode, String time) {
         // kisToken redis에서 가져오기 (필요하면 재발급)
-        String token = kisTokenService.getAccessToken().block();
+        String token = kisTokenService.getAccessToken();
         if (token == null) {
             throw new RuntimeException("KIS 토큰 접근 실패");
         }

--- a/backend/stock/src/main/java/com/sog/stock/application/service/kis/KisTokenService.java
+++ b/backend/stock/src/main/java/com/sog/stock/application/service/kis/KisTokenService.java
@@ -1,5 +1,7 @@
 package com.sog.stock.application.service.kis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sog.stock.application.service.RedisService;
 import com.sog.stock.domain.dto.kis.KisTokenResponseDTO;
 import java.time.Duration;
@@ -9,12 +11,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Service
 @Slf4j
@@ -33,6 +34,7 @@ public class KisTokenService {
 
     private final WebClient kisApiWebClient;
     private final RedisService redisService;
+    private final ObjectMapper objectMapper;
 
     @Value("${kis.realtime-stock.appkey}")
     private String appKey;
@@ -41,16 +43,20 @@ public class KisTokenService {
     private String appSecret;
 
     // get access token from redis
-    public Mono<String> getAccessToken() {
+    // Mono -> String (blocking)
+    public String getAccessToken() {
         log.info("kis토큰 접근 메서드 호출");
         String token = redisService.getValue(REDIS_TOKEN_KEY_NAME);
-        if (token != null) {
-            return Mono.just(token);
+        if (token != null && !token.isEmpty()) {
+            log.info("Redis에 토큰이 존재합니다 : {}", token);
+            return token;
         }
+        log.info("Redis에 토큰이 없거나 유효하지 않습니다. 새로운 토큰 발급 요청을 시도합니다.");
         return requestNewToken();
     }
 
-    private Mono<String> requestNewToken() {
+    // Mono -> String (blocking)
+    private String requestNewToken() {
         log.info("Preparing token request with appkey: {}", appKey);
         // 요청에 필요한 데이터
         Map<String, String> requestBody = new HashMap<>();
@@ -58,32 +64,91 @@ public class KisTokenService {
         requestBody.put(REQUEST_BODY_APPKEY_KEY, appKey);
         requestBody.put(REQUEST_BODY_APPSECRET_KEY, appSecret);
 
-        return kisApiWebClient.post()
-            .uri(KIS_TOKEN_ENDPOINT)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestBody)
-            .retrieve()
-            .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
-                return clientResponse.bodyToMono(String.class).flatMap(errorBody -> {
-                    System.out.println("4xx Error: " + errorBody);
-                    return Mono.error(new RuntimeException(ERROR_MSG_4XX_CLIENT));
-                });
-            })
-            .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
-                return clientResponse.bodyToMono(String.class).flatMap(errorBody -> {
-                    System.out.println("5xx Error: " + errorBody);
-                    return Mono.error(new RuntimeException(ERROR_MSG_5XX_SERVER));
-                });
-            })
-            .bodyToMono(KisTokenResponseDTO.class)
-            .flatMap(response -> {
-                if (response.getAccessToken() == null) {
-                    return Mono.error(new NullPointerException(ERROR_MSG_ACCESS_TOKEN_NULL));
-                }
-                redisService.setValues(REDIS_TOKEN_KEY_NAME, response.getAccessToken(),
-                    Duration.ofSeconds(response.getExpiresIn()));
-                return Mono.just(response.getAccessToken());
-            });
+        String responseBodyString;
+        try {
+            String requestBodyJson = objectMapper.writeValueAsString(
+                requestBody); // 요청 바디를 JSON 문자열로 변환
+
+            responseBodyString = kisApiWebClient.post()
+                .uri(KIS_TOKEN_ENDPOINT)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(requestBodyJson) // JSON 문자열을 바디로 전달
+                .retrieve() // 응답 상태 코드 검증 및 응답 본문 추출 시작
+                .bodyToMono(String.class) // 응답 본문을 String Mono로 받음
+                .block();
+
+        } catch (WebClientResponseException e) {
+            String errorResponse = e.getResponseBodyAsString();
+            if (e.getStatusCode().is4xxClientError()) {
+                log.error("{}: HTTP Status {} - {}", ERROR_MSG_4XX_CLIENT, e.getStatusCode(),
+                    errorResponse, e);
+                throw new RuntimeException(ERROR_MSG_4XX_CLIENT + ": " + errorResponse, e);
+            } else if (e.getStatusCode().is5xxServerError()) {
+                log.error("{}: HTTP Status {} - {}", ERROR_MSG_5XX_SERVER, e.getStatusCode(),
+                    errorResponse, e);
+                throw new RuntimeException(ERROR_MSG_5XX_SERVER + ": " + errorResponse, e);
+            } else {
+                log.error("KIS 토큰 요청 중 WebClient 오류 발생 (HTTP {}): {}", e.getStatusCode(),
+                    e.getMessage(), e);
+                throw new RuntimeException("KIS token request failed: " + e.getMessage(), e);
+            }
+        } catch (JsonProcessingException e) { // 요청 바디 JSON 변환 실패 시
+            log.error("Error converting request body to JSON: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to prepare token request body", e);
+        } catch (Exception e) {
+            log.error("KIS 토큰 요청 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to request new KIS token due to unexpected error",
+                e);
+        }
+
+        KisTokenResponseDTO responseDto;
+        try {
+            responseDto = objectMapper.readValue(responseBodyString, KisTokenResponseDTO.class);
+
+            if (responseDto.getAccessToken() == null || responseDto.getAccessToken().isEmpty()) {
+                log.error("{}: Response: {}", ERROR_MSG_ACCESS_TOKEN_NULL, responseBodyString);
+                throw new NullPointerException(ERROR_MSG_ACCESS_TOKEN_NULL);
+            }
+
+            // Redis에 토큰 저장 (블로킹 setValues 그대로 사용)
+            redisService.setValues(REDIS_TOKEN_KEY_NAME, responseDto.getAccessToken(),
+                Duration.ofSeconds(responseDto.getExpiresIn()));
+
+            return responseDto.getAccessToken();
+        } catch (JsonProcessingException e) { // 응답 JSON 파싱 실패 시
+            log.error("Error mapping KIS token response to DTO: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to map KIS token response to DTO", e);
+        } catch (Exception e) {
+            log.error("KIS 토큰 응답 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to process KIS token response", e);
+        }
+
+//        return kisApiWebClient.post()
+//            .uri(KIS_TOKEN_ENDPOINT)
+//            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+//            .bodyValue(requestBody)
+//            .retrieve()
+//            .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+//                return clientResponse.bodyToMono(String.class).flatMap(errorBody -> {
+//                    System.out.println("4xx Error: " + errorBody);
+//                    return Mono.error(new RuntimeException(ERROR_MSG_4XX_CLIENT));
+//                });
+//            })
+//            .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+//                return clientResponse.bodyToMono(String.class).flatMap(errorBody -> {
+//                    System.out.println("5xx Error: " + errorBody);
+//                    return Mono.error(new RuntimeException(ERROR_MSG_5XX_SERVER));
+//                });
+//            })
+//            .bodyToMono(KisTokenResponseDTO.class)
+//            .flatMap(response -> {
+//                if (response.getAccessToken() == null) {
+//                    return Mono.error(new NullPointerException(ERROR_MSG_ACCESS_TOKEN_NULL));
+//                }
+//                redisService.setValues(REDIS_TOKEN_KEY_NAME, response.getAccessToken(),
+//                    Duration.ofSeconds(response.getExpiresIn()));
+//                return Mono.just(response.getAccessToken());
+//            });
 
     }
 }


### PR DESCRIPTION
## Issue
#9 

- 모든 Mono 반환 타입을 String으로 변경하여 명시적인 블로킹 통신 모델을 따르도록 함.
- WebClient 호출 시 .block()을 사용하여 동기적 처리를 명확히 하고, Mono 리액티브 오퍼레이터들을 제거함.
- ObjectMapper를 주입받아 요청 및 응답 본문 처리를 개선함.
- RedisService 및 KisRealTimeWebSocketKeyService와 통신 방식의 일관성을 확보함.
- KisTokenService.getAccessToken()이 String을 직접 반환하도록 변경됨에 따라, 해당 메서드 호출 시 사용하던 .block()을 제거함.